### PR TITLE
Add pattern-based string generation

### DIFF
--- a/app.js
+++ b/app.js
@@ -367,6 +367,17 @@ function generatePhone(areaCodes = AREA_CODES){
   return `+54${area}${num}`;
 }
 
+function generateFromPattern(expr){
+  let out = '';
+  for (const ch of expr){
+    if (ch === 'A') out += String.fromCharCode(65 + Math.floor(Math.random()*26));
+    else if (ch === 'a') out += String.fromCharCode(97 + Math.floor(Math.random()*26));
+    else if (ch === '9') out += Math.floor(Math.random()*10);
+    else out += ch;
+  }
+  return out;
+}
+
 // ========= Estado =========
 let state = {
   alias: '',
@@ -391,7 +402,8 @@ let state = {
   dateTo: '',
   amountOut: '',
   orderOut: '',
-  phone: ''
+  phone: '',
+  patternOut: ''
 };
 
 function save(){ localStorage.setItem(LS_KEY, JSON.stringify(state)); }
@@ -458,6 +470,9 @@ function renderAll(){
 
   $('amount-out').value = state.amountOut || '';
   $('order-out').value = state.orderOut || '';
+
+  $('pattern-out').value = state.patternOut || '';
+  setStatus('pattern-status', !!state.patternOut, 'Generado', '');
 
   $('phone').value = state.phone || '';
   setStatus('phone-status', !!state.phone, 'Generado', '');
@@ -625,6 +640,15 @@ document.addEventListener('DOMContentLoaded', () => {
     state.orderOut = `${pref}-${stamp}-${rnd}`;
     $('order-out').value = state.orderOut;
     setStatus('order-status', true, 'Generado', '');
+    save();
+  });
+
+  // Patrón
+  $('gen-pattern').addEventListener('click', () => {
+    const expr = $('pattern-exp').value || '';
+    state.patternOut = generateFromPattern(expr);
+    $('pattern-out').value = state.patternOut;
+    setStatus('pattern-status', true, 'Generado', '');
     save();
   });
 

--- a/index.html
+++ b/index.html
@@ -294,6 +294,27 @@
 
       <div class="card">
         <div class="card-head">
+          <h2>Generación por patrón</h2>
+        </div>
+        <div class="field">
+          <label>Expresión</label>
+          <div class="control">
+            <input id="pattern-exp" placeholder="AAA-999" title="Patrón con A=letra, a=letra minúscula y 9=dígito" value="AAA-999"/>
+            <button id="gen-pattern" class="primary small">Generar</button>
+          </div>
+        </div>
+        <div class="field">
+          <label>Resultado</label>
+          <div class="control">
+            <input id="pattern-out" readonly title="Cadena generada según el patrón indicado."/>
+            <button class="copy" data-target="pattern-out">Copiar</button>
+          </div>
+          <div id="pattern-status" class="status"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
           <h2>Número telefónico</h2>
           <div class="head-actions"><button id="regen-phone" class="primary small">Regenerar</button></div>
         </div>


### PR DESCRIPTION
## Summary
- allow generating custom strings from simple patterns (A for letters, 9 for digits)
- add UI form to input pattern expressions and copy output

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689bf96db674832ba89366472aa7f4d4